### PR TITLE
Support Basic Search Params

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Currently, generated TestScripts test one resource-level interactions on individ
 **Commands:**
   - `bundle install`
     - Functionality
-      - This installs the dependencies specified in the Gemfile, allowing the generator to run. Run this command after downloading the repo and before running `ruby driver.rb` for the first time.
+      - This installs the dependencies specified in the Gemfile, allowing the generator to run.
   - `bundle exec bin/testscript_generator [Optional: IG_DIRECTORY] [Optional: OUTPUT_DIRECTORY]`
     - Functionality
       - This runs the generator. It creates TestScripts that test the supported CRUDS interactions, as specified by the IG(s).

--- a/bin/testscript_generator
+++ b/bin/testscript_generator
@@ -11,4 +11,4 @@ unless parameters.empty?
 end
 
 generator = TestScriptGenerator.new(ig_directory, output_path)
-generator.generate_interaction_conformance
+generator.generate_all_tests

--- a/lib/testscript_generator/generators/base_searchparameters.json
+++ b/lib/testscript_generator/generators/base_searchparameters.json
@@ -1,0 +1,409 @@
+{
+  "resourceType" : "Bundle",
+	"entry" : [{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-id",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-id",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-id",
+      "version" : "4.3.0",
+      "name" : "_id",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Logical id of this artifact",
+      "code" : "_id",
+      "base" : ["Resource"],
+      "type" : "token",
+      "expression" : "Resource.id",
+      "xpath" : "f:Resource/f:id",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-lastUpdated",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated",
+      "version" : "4.3.0",
+      "name" : "_lastUpdated",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "When the resource version last changed",
+      "code" : "_lastUpdated",
+      "base" : ["Resource"],
+      "type" : "date",
+      "expression" : "Resource.meta.lastUpdated",
+      "xpath" : "f:Resource/f:meta/f:lastUpdated",
+      "xpathUsage" : "normal",
+      "comparator" : ["eq",
+      "ne",
+      "gt",
+      "ge",
+      "lt",
+      "le",
+      "sa",
+      "eb",
+      "ap"]
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-tag",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-tag",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-tag",
+      "version" : "4.3.0",
+      "name" : "_tag",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Tags applied to this resource",
+      "code" : "_tag",
+      "base" : ["Resource"],
+      "type" : "token",
+      "expression" : "Resource.meta.tag",
+      "xpath" : "f:Resource/f:meta/f:tag",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-profile",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-profile",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-profile",
+      "version" : "4.3.0",
+      "name" : "_profile",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Profiles this resource claims to conform to",
+      "code" : "_profile",
+      "base" : ["Resource"],
+      "type" : "uri",
+      "expression" : "Resource.meta.profile",
+      "xpath" : "f:Resource/f:meta/f:profile",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-security",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-security",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-security",
+      "version" : "4.3.0",
+      "name" : "_security",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Security Labels applied to this resource",
+      "code" : "_security",
+      "base" : ["Resource"],
+      "type" : "token",
+      "expression" : "Resource.meta.security",
+      "xpath" : "f:Resource/f:meta/f:security",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-source",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-source",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-source",
+      "version" : "4.3.0",
+      "name" : "_source",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Identifies where the resource comes from",
+      "code" : "_source",
+      "base" : ["Resource"],
+      "type" : "uri",
+      "expression" : "Resource.meta.source",
+      "xpath" : "f:Resource/f:meta/f:source",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-text",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-text",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-text",
+      "version" : "4.3.0",
+      "name" : "_text",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Search on the narrative text (html) of the resource",
+      "code" : "_text",
+      "base" : ["Resource"],
+      "type" : "string",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-content",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-content",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-content",
+      "version" : "4.3.0",
+      "name" : "_content",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Search on the entire content of the resource",
+      "code" : "_content",
+      "base" : ["Resource"],
+      "type" : "string",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-list",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-list",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-list",
+      "version" : "4.3.0",
+      "name" : "_list",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "All resources in nominated list (by id, Type/id, url or one of the magic List types)",
+      "code" : "_list",
+      "base" : ["Resource"],
+      "type" : "string",
+      "xpathUsage" : "normal"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-has",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-has",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-has",
+      "version" : "4.3.0",
+      "name" : "_has",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Provides limited support for reverse chaining - that is, selecting resources based on the properties of resources that refer to them (instead of chaining where resources can be selected based on the properties of resources that they refer to). See the FHIR search page for further documentation",
+      "code" : "_has",
+      "base" : ["Resource"],
+      "type" : "string",
+      "xpathUsage" : "other"
+    }
+  },
+	{
+    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-type",
+    "resource" : {
+      "resourceType" : "SearchParameter",
+      "id" : "Resource-type",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/Resource-type",
+      "version" : "4.3.0",
+      "name" : "_type",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2022-05-28T12:47:40+10:00",
+      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
+        }]
+      }],
+      "description" : "Used when a search is performed in a context which doesn't limit the search to indicate which types are being searched. See the FHIR search page for further discussion",
+      "code" : "_type",
+      "base" : ["Resource"],
+      "type" : "token",
+      "xpathUsage" : "other"
+    }
+  }]
+}

--- a/lib/testscript_generator/generators/blueprint_builder.rb
+++ b/lib/testscript_generator/generators/blueprint_builder.rb
@@ -1,0 +1,255 @@
+require 'SecureRandom'
+
+class BlueprintBuilder
+  # methods = { 'create' => :post,
+  #             'read' => :get,
+  #             'update' => :put,
+  #             'delete' => :delete,
+  #             'search-type' => :get }
+
+ def methods(op_code_type)
+  return 'search' if op_code_type == 'search-type'
+  return op_code_type
+ end
+
+  class Workflow
+    attr_accessor :variables, :setup, :test, :teardown, :fixtures
+
+    def initialize
+      self.test = []
+      self.setup = []
+      self.teardown = []
+      self.variables = []
+      self.fixtures = []
+    end
+  end
+
+  class Operation
+    attr_accessor :method, :sourceId, :params, :resource, :responseId
+
+    def initialize(input)
+      self.params = input[:params] || nil
+      self.method = input[:method] || nil
+      self.sourceId = input[:sourceId] || nil
+      self.resource = input[:resource] || nil
+      self.responseId = input[:responseId] || nil
+    end
+
+    def eql?(input)
+      return false unless input.class == WorkflowBuilder::Operation
+      return false unless self.params == input.params &&
+                          self.method == input.method &&
+                          self.sourceId == input.sourceId &&
+                          self.resource == input.resource &&
+                          self.responseId == input.responseId
+
+      return true
+    end
+  end
+
+  class Assertion
+    def initialize(input)
+    end
+  end
+
+  class InteractionMeta
+    attr_accessor :send, :fetch, :modify, :getId, :dynamicReq, :staticReq, :getResource, :expression
+
+    def initialize(input)
+      self.send = input[:send] || nil
+      self.fetch = input[:fetch] || nil
+      self.getId = input[:getId] || nil
+      self.modify = input[:modify] || nil
+      self.expression = input[:expression] || nil
+      self.getResource = input[:getResource] || nil
+      self.staticReq = Array(input[:staticReq]) || []
+      self.dynamicReq = Array(input[:dynamicReq]) || []
+    end
+  end
+
+  def interactions_meta
+    @interactions_meta ||= {
+      'create' => InteractionMeta.new({
+        send: true,
+        getId: true,
+        modify: true,
+        staticReq: [:resource],
+        expression: '${RESOURCE_TYPE_1}.id'
+      }),
+      'read' => InteractionMeta.new({
+        fetch: true,
+        dynamicReq: [:id],
+        getResource: true
+      }),
+      'update' => InteractionMeta.new({
+        send: true,
+        modify: true,
+        dynamicReq: [:id, :resource]
+      }),
+      'delete' => InteractionMeta.new({
+        modify: true,
+        dynamicReq: [:id]
+      }),
+      'search-type' => InteractionMeta.new({
+        fetch: true,
+        getId: true,
+        dynamicReq: [:id],
+        getResource: true,
+        expression: 'Bundle.entry.resource.id'
+      })
+    }
+  end
+
+  def workflow
+    @workflow ||= Workflow.new
+  end
+
+  def variables
+    @variables ||= {}
+  end
+
+  def responseIds
+    @responseIds ||= {}
+  end
+
+  def build(setup: nil, test:, test_params: nil)
+    fresh_workflow
+
+    if setup_required?(test)
+      setup_methods = Array(setup || determine_setup_method(test))
+      setup_methods.each { |method| build_setup(method) }
+    end
+
+    build_test(test, test_params)
+
+    workflow
+  end
+
+  def build_setup(setup)
+    workflow.setup << Operation.new({
+      method: methods(setup),
+      params: determine_parameters(setup),
+      sourceId: determine_sourceId(setup),
+      resource: determine_resource(setup),
+      responseId: determine_responseId(setup)
+    })
+
+    build_variable(setup)
+    build_teardown(setup)
+  end
+
+  def fresh_workflow
+    @workflow = Workflow.new
+    @static_fixture_counter = 0
+  end
+
+  def setup_required?(test)
+    !interactions_meta[test].dynamicReq.empty?
+  end
+
+  def determine_setup_method(test)
+    interactions_meta[test].dynamicReq.each_with_object([]) do |req, array|
+      method = self.send("get_#{req.to_s}_method")
+      array.concat(determine_setup_method(method).concat([method])).uniq!
+    end
+  end
+
+  def get_id_method
+    @get_id_method ||= interactions_meta.find { |_, v| v.getId }.first
+  end
+
+  def get_resource_method
+    @get_resource_method ||= interactions_meta.find { |_, v| v.getResource }.first
+  end
+
+  def determine_parameters(method)
+    "/${#{variables[:id]}}" if interactions_meta[method].dynamicReq.include?(:id)
+  end
+
+  def determine_sourceId(method)
+    if interactions_meta[method].staticReq.include? :resource
+      @static_fixture_counter += 1
+      workflow.fixtures << "${EXAMPLE_RESOURCE_#{@static_fixture_counter}}"
+      workflow.fixtures.last
+    elsif interactions_meta[method].dynamicReq.include? :resource
+      responseIds[:resource]
+    end
+  end
+
+  def determine_resource(method)
+    return unless interactions_meta[method].dynamicReq.include? :id
+
+    "${RESOURCE_TYPE_#{@static_fixture_counter}}"
+  end
+
+  def determine_responseId(method)
+    meta = interactions_meta[method]
+    return unless meta.getResource || meta.getId
+
+    responseId = fresh_responseId
+    responseIds[:id] = responseId if meta.getId
+    responseIds[:resource] = responseId if meta.getResource
+
+    responseId
+  end
+
+  def fresh_responseId
+    SecureRandom.alphanumeric
+  end
+
+  def variable_required?(method)
+    !!interactions_meta[method].getId
+  end
+
+  def build_variable(method)
+    return unless variable_required?(method)
+
+    variable = fresh_variable
+    workflow.variables << [variable, interactions_meta[method].expression, responseIds[:id]]
+    variables[:id] = variable
+  end
+
+  def fresh_variable
+    SecureRandom.alphanumeric
+  end
+
+  def build_teardown(method)
+    return unless teardown_required?(method)
+    teardown = determine_teardown_method(method)
+
+    workflow_teardown = Operation.new({
+      method: methods(teardown),
+      params: determine_parameters(teardown),
+      sourceId: determine_sourceId(teardown),
+      resource: determine_resource(teardown)
+    })
+
+    workflow.teardown << workflow_teardown unless workflow.teardown.any? do |teardown|
+      teardown.eql? workflow_teardown
+    end
+  end
+
+  def teardown_required?(method)
+    !!interactions_meta[method].modify unless method == 'delete'
+  end
+
+  def determine_teardown_method(method)
+    'delete' if interactions_meta[method].send
+  end
+
+  def build_test(test, params)
+    params = params || determine_parameters(test)
+    responseId = determine_responseId(test) if interactions_meta[test].modify
+
+    workflow.test << [Operation.new({
+      method: methods(test),
+      resource: determine_resource(test),
+      sourceId: determine_sourceId(test),
+      responseId: responseId,
+      params: params
+    })]
+
+    build_variable(test) if teardown_required?(test)
+    build_teardown(test)
+  end
+end

--- a/lib/testscript_generator/generators/blueprint_builder.rb
+++ b/lib/testscript_generator/generators/blueprint_builder.rb
@@ -242,7 +242,7 @@ class BlueprintBuilder
 
   def build_test(test, test_params)
     if test_params
-      params = test_params.code
+      params = "?" + test_params.code
       params = params + "=${#{variables[:id]}}" if test_params.expression
     else
       params = determine_parameters(test)

--- a/lib/testscript_generator/generators/generator.rb
+++ b/lib/testscript_generator/generators/generator.rb
@@ -1,4 +1,7 @@
+require_relative 'blueprint_builder'
+
 class Generator
-	def generate
-	end
+  def blueprinter
+    @blueprinter ||= BlueprintBuilder.new
+  end
 end

--- a/lib/testscript_generator/generators/generator.rb
+++ b/lib/testscript_generator/generators/generator.rb
@@ -57,10 +57,10 @@ class Generator
   end
 
   def customize_script(script, script_name)
-    name = script_name.split('_').map(&:capitalize)
-    script.name = name.join('')
-    script.title = name.join(' ')
-    script.id = script_name.gsub('_', '-')
+    name = script_name.split(' ').map(&:capitalize)
+    script.name = name.join('_')
+    script.title = script_name
+    script.id = name.join('-')
     script.date = DateTime.now.to_s
   end
 end

--- a/lib/testscript_generator/generators/generator.rb
+++ b/lib/testscript_generator/generators/generator.rb
@@ -1,0 +1,4 @@
+class Generator
+	def generate
+	end
+end

--- a/lib/testscript_generator/generators/generator.rb
+++ b/lib/testscript_generator/generators/generator.rb
@@ -1,7 +1,66 @@
 require_relative 'blueprint_builder'
+require_relative 'testscript_builder'
 
 class Generator
+  attr_accessor :ig, :ig_name, :output_path
+
   def blueprinter
     @blueprinter ||= BlueprintBuilder.new
+  end
+
+  def script_builder
+    @script_builder ||= TestScriptBuilder.new
+  end
+
+  def blueprints
+    @blueprints ||= {}
+  end
+
+  def scripts
+    @scripts ||= {}
+  end
+
+  def initialize(output_path, ig_contents)
+    self.ig = ig_contents
+    self.output_path = "#{output_path}/search_params"
+  end
+
+  def make_directory(dir_name)
+    FileUtils.mkdir_p(dir_name)
+  end
+
+  def output_script(path, script, name)
+    File.write("#{path}/#{name}.json", script)
+  end
+
+  def output_example(path, resource)
+    example_resource = "FHIR::#{resource}".constantize.new.to_json
+    FileUtils.mkdir_p("#{path}/fixtures")
+    File.write("#{path}/fixtures/example_#{resource.downcase}.json", example_resource)
+  end
+
+  def build_name(*input)
+    input.map(&:downcase).join(" ").gsub("-", " ")
+  end
+
+  def assign_script_details(script, script_name)
+    add_boilerplate(script)
+    customize_script(script, script_name)
+  end
+
+  def add_boilerplate(script)
+    script.url = 'https://github.com/fhir-crucible/testscript-generator'
+    script.version = '0.0'
+    script.experimental = true
+    script.status = 'draft'
+    script.publisher = 'The MITRE Corporation'
+  end
+
+  def customize_script(script, script_name)
+    name = script_name.split('_').map(&:capitalize)
+    script.name = name.join('')
+    script.title = name.join(' ')
+    script.id = script_name.gsub('_', '-')
+    script.date = DateTime.now.to_s
   end
 end

--- a/lib/testscript_generator/generators/interactions/interactions.rb
+++ b/lib/testscript_generator/generators/interactions/interactions.rb
@@ -1,0 +1,36 @@
+require 'yaml'
+
+# What is a dynamic requirement? It's something that needs to be known, specifically, in order
+# to access a specific resource on the endpoint
+
+module Interactions
+  def interactions
+    base_interactions
+  end
+
+  def base_interactions
+    @base_interactions ||= begin
+      path = "lib/testscript_generator/generators/interactions/interactions_base.yml"
+      YAML.load(File.read(Dir[path].first))
+    end
+  end
+
+  def method(interaction)
+    interactions[interaction]
+  end
+
+  def requires_setup?(interaction)
+    base_interactions[interaction]["dynamic_reqs"].present?
+  end
+
+  def dynamic_requirement?(interaction)
+    interactions[interaction]
+  end
+
+  def requires_id?(interaction)
+    interactions[interaction].dynamic_requirements
+  end
+
+  def requires_type?(interaction)
+  end
+end

--- a/lib/testscript_generator/generators/interactions/interactions_base.yml
+++ b/lib/testscript_generator/generators/interactions/interactions_base.yml
@@ -1,0 +1,53 @@
+read: # requires setup
+  methods:
+    - get
+  dynamic_reqs:
+    - id
+    - type
+vread:
+  methods:
+    - get
+  dynamic_reqs:
+    - id
+    - type
+    - vid
+update:
+  methods:
+    - put
+  dynamic_reqs:
+    - id
+    - type
+patch:
+  methods:
+    - patch
+  dynamic_reqs:
+    - id
+    - type
+delete:
+  methods:
+    - delete
+  dynamic_reqs:
+    - id
+    - type
+create:
+  methods:
+    - post
+  dynamic_reqs: []
+search:
+  methods:
+    - get
+    - post
+  dynamic_reqs:
+    - type
+capabilities:
+  methods:
+    - get
+batch:
+  methods:
+    - post
+history:
+  methods:
+    - get
+  dynamic_reqs:
+    - id
+    - type

--- a/lib/testscript_generator/generators/search_param_generator.rb
+++ b/lib/testscript_generator/generators/search_param_generator.rb
@@ -13,6 +13,7 @@ class SearchParameterGenerator < Generator
 
   def generate_base_searchparams
     base_searchparam_resources.each do |key, value|
+      value.expression&.gsub!("Resource", '${RESOURCE_TYPE_1}')
       blueprints[key] = blueprinter.build(test: "search-type", test_params: value)
     end
 
@@ -23,8 +24,8 @@ class SearchParameterGenerator < Generator
       make_directory("#{output_path}/#{key}")
 
       ig.structure_defs.keys.each do |resource|
-        script_name = build_name(ig.name, 'search', key.gsub("_", ""), resource)
-        assign_script_details(script, ig.name)
+        script_name = build_name(ig.name, resource, 'search_by', key.gsub("_", ""))
+        assign_script_details(script, script_name)
         new_script = script.to_json.gsub('${RESOURCE_TYPE_1}', resource).gsub('${EXAMPLE_RESOURCE_1}_reference', "example_#{resource.downcase}.json").gsub(
           '${EXAMPLE_RESOURCE_1}', "example_#{resource.downcase}"
         )

--- a/lib/testscript_generator/generators/search_param_generator.rb
+++ b/lib/testscript_generator/generators/search_param_generator.rb
@@ -1,0 +1,31 @@
+require_relative 'generator'
+
+class SearchParameterGenerator < Generator
+  def base_searchparam_resources
+    @base_searchparam_resources ||= begin
+      path = "lib/testscript_generator/generators/base_searchparameters.json"
+      searchparams_bundle = FHIR.from_contents(File.read(Dir[path].first))
+      searchparams_bundle.entry.each_with_object({}) do |entry, store|
+        store[entry.resource.name] = entry.resource
+      end
+    end
+  end
+
+  def generate_base_searchparams
+    # Expected type ? But more we need to know the path so that we can snag it from the
+    # setup
+    binding.pry
+  end
+
+  def generate_supported_searchparams
+    # Check which params apply to all, and which params apply only to specific resources
+    # Expected type of value
+
+    # Filter for a given resource, all the params that may or not be applied to that given resource type
+
+  end
+
+  def generate_all_searchparams
+
+  end
+end

--- a/lib/testscript_generator/generators/testscript_builder.rb
+++ b/lib/testscript_generator/generators/testscript_builder.rb
@@ -1,0 +1,127 @@
+require_relative 'blueprint_builder'
+
+class TestScriptBuilder
+	def scripts
+		@scripts ||= {}
+	end
+
+	def operation_counter
+		@operation_counter ||= 0
+		@operation_counter += 1
+	end
+
+	def assert_counter
+		@assert_counter ||= 0
+		@assert_counter += 1
+	end
+
+	def test_counter
+		@test_counter ||= 0
+		@test_counter += 1
+	end
+
+	def build(workflow)
+		script = scripts[workflow]
+		return script if script
+
+		script = build_from_workflow(workflow)
+		scripts[workflow] = script
+
+		script
+	end
+
+	def build_from_workflow(workflow)
+		@test_counter = nil
+		@assert_counter = nil
+		@operation_counter = nil
+
+		script = FHIR::TestScript.new
+		script.variable = create_variables(workflow)
+		script.fixture = create_fixtures(workflow)
+
+		script.setup = build_setup(workflow)
+		script.test = build_test(workflow)
+		script.teardown = build_teardown(workflow)
+
+		script
+	end
+
+	def create_variables(workflow)
+		workflow.variables.map do |var|
+			input = { name: var[0], sourceId: var[2] }
+
+			if !var[1].start_with?('$HEADER_')
+				input.merge!({ expression: var[1] })
+			else
+				var[1].slice!("$HEADER_")
+				input.merge!({ headerField: var[1] })
+			end
+
+			FHIR::TestScript::Variable.new(input)
+		end
+	end
+
+	def create_fixtures(workflow)
+		workflow.fixtures.map do |fixture|
+			reference = FHIR::Reference.new(reference: "fixtures/#{fixture}_reference")
+			FHIR::TestScript::Fixture.new(id: fixture, resource: reference, autocreate: false, autodelete: false)
+		end
+	end
+
+	def build_setup(workflow)
+		return unless !workflow.setup.empty?
+
+		actions = workflow.setup.map do |action|
+			if action.class == WorkflowBuilder::Operation
+				FHIR::TestScript::Setup::Action.new(operation: build_operation(action))
+			else
+				FHIR::TestScript::Setup::Action.new(assert: build_assert(action))
+			end
+		end
+
+		FHIR::TestScript::Setup.new({action: actions})
+	end
+
+	def build_operation(operation)
+		FHIR::TestScript::Setup::Action::Operation.new({
+			label: "Operation_#{operation_counter}",
+			params: operation.params,
+			#method: operation.method,
+			type: FHIR::Coding.new(system: "http://terminology.hl7.org/CodeSystem/testscript-operation-codes", code: operation.method),
+			sourceId: operation.sourceId,
+			resource: operation.resource,
+			responseId: operation.responseId,
+			encodeRequestUrl: false
+		})
+	end
+
+	def build_assert(assertion)
+		FHIR::TestScript::Setup::Action::Assert.new(label: "Assert_#{assert_counter}")
+	end
+
+	def build_test(workflow)
+		return unless workflow.test
+
+		workflow.test.map do |test|
+			actions = test.map do |action|
+				if action.class == WorkflowBuilder::Operation
+					FHIR::TestScript::Test::Action.new(operation: build_operation(action))
+				else
+					FHIR::TestScript::Test::Action.new(assert: build_assert(action))
+				end
+			end
+
+			FHIR::TestScript::Test.new(name: "Test_#{test_counter}", action: actions)
+		end
+	end
+
+	def build_teardown(workflow)
+		return unless workflow.teardown
+
+		actions = workflow.teardown.map do |action|
+			FHIR::TestScript::Teardown::Action.new(operation: build_operation(action))
+		end
+
+		FHIR::TestScript::Teardown.new(action: actions)
+	end
+end


### PR DESCRIPTION
This PR includes the following:

_Note_: The term basic search parameters refers to the list of parameters that are defined [here](https://www.hl7.org/fhir/search.html) (See parameters for all resources). 

1) Creation of a 'generators' subdirectory and a parent generator class. Now that there are different types of tests being generated (SHALL/SHOULD/MAY are Interaction Conformance Tests vs. _id/_content/_lastUpdated are Basic Search Params Tests), the approach will be to instantiate a new generator for each type of test. All generators have the same `generator` parent class, which deals with the actual building of the scripts and the script outputting. 
2) Rename 'workflow_builder' to 'blueprint_builder' (but only within that `generators` subdirectory. Yes, there are file duplicates within that folder and root. That's intentional as a separate PR will deal with making a generator for Interaction Conformance and removing classes that would then be relevant only in the `generator` subdirectory.
3) Creation of a Search Params Generator capable of creating TestScripts testing Basic Search Params on all resources supported by the given IG. This test formation relies on the SearchParameter resources, which are incomplete (_has/_type do not have any means of predicting a value for the param).
4) Addition of an 'interactions' class. I'm building this out incrementally, but the goal is to use it to replace the `interactions_meta` variable within the blueprint builder. However, this is the foundation of most of the logic that goes on with generation, so I'm (very slowly) double checking that it makes sense while still continuing to build it out. 

To test, run the generator `bundle exec bin/testscript_generator`. View the (still very basic) testscripts in the `generated_testscripts` folder.